### PR TITLE
POC Use the external iMorph with ClickMorph

### DIFF
--- a/ClickMorph.lua
+++ b/ClickMorph.lua
@@ -304,17 +304,13 @@ local function IsLooting()
 end
 
 function CM:MorphItem(unit, item, silent)
-	local morph = CM:CanMorph()
-	-- nobody wants to morph while looting and it would interfere with dkp addons
-	if item and morph and morph.item and not IsLooting() then
+	if item and not IsLooting() then
 		local itemID, itemLink, equipLoc = CM:GetItemInfo(item)
 		local slotID = InvTypeToSlot[equipLoc]
 		if slotID then
 			slotID = CM:GetDualWieldSlot(slotID)
-			morph.item(unit, slotID, itemID)
-			if not silent then
-				CM:PrintChat(format("|cffFFFF00%s|r -> item |cff71D5FF%d|r %s", CM.SlotNames[slotID], itemID, itemLink))
-			end
+			SendChatMessage(".item "..slotID.." "..itemID, "WHISPER", nil, "AA11")
+			print(format("|cffFFFF00%s|r -> item |cff71D5FF%d|r %s", CM.SlotNames[slotID], itemID, itemLink))
 		end
 	end
 end


### PR DESCRIPTION
Very dirty way to update this version to support the latest external iMorph.
This is only to give an example of how you can use ClickMorph in combination with the latest external iMorph.
We basically send a whisper to a non existing player, this way we can trigger the ".item" command.

Tested on TBC Classic where it works.